### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/kantord/tauler/compare/tauler-v0.1.0...tauler-v0.1.1) - 2026-08-12
+
+### Added
+
+- expose the wallpaper behind a panel as a root-bg image ([#358](https://github.com/kantord/tauler/pull/358))
+- support background surfaces ([#354](https://github.com/kantord/tauler/pull/354))
+
+### Fixed
+
+- *(deps)* update rust crate zbus to 5.19.0 ([#357](https://github.com/kantord/tauler/pull/357))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4608,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cached",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "image",
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -4663,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "image",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-ui-macro"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-i3", "tauler-notify", "tauler-ui-macro", "tauler-docgen"
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"

--- a/tauler-notify/CHANGELOG.md
+++ b/tauler-notify/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/kantord/tauler/compare/tauler-notify-v0.1.0...tauler-notify-v0.1.1) - 2026-08-12
+
+### Fixed
+
+- *(deps)* update rust crate zbus to 5.19.0 ([#357](https://github.com/kantord/tauler/pull/357))

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.0...tauler-screenshot-v0.1.1) - 2026-08-12
+
+### Other
+
+- updated the following local packages: tauler

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -26,7 +26,7 @@ name = "tauler-screenshot"
 path = "src/main.rs"
 
 [dependencies]
-tauler = { path = "..", version = "0.1.0" }
+tauler = { path = "..", version = "0.1.1" }
 clap = { version = "4.6.6", features = ["derive"] }
 image = "0.25.10"
 serde_json = "1.0.151"


### PR DESCRIPTION



## 🤖 New release

* `tauler`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `tauler-notify`: 0.1.0 -> 0.1.1
* `tauler-screenshot`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler`

<blockquote>

## [0.1.1](https://github.com/kantord/tauler/compare/tauler-v0.1.0...tauler-v0.1.1) - 2026-08-12

### Added

- expose the wallpaper behind a panel as a root-bg image ([#358](https://github.com/kantord/tauler/pull/358))
- support background surfaces ([#354](https://github.com/kantord/tauler/pull/354))

### Fixed

- *(deps)* update rust crate zbus to 5.19.0 ([#357](https://github.com/kantord/tauler/pull/357))
</blockquote>

## `tauler-notify`

<blockquote>

## [0.1.1](https://github.com/kantord/tauler/compare/tauler-notify-v0.1.0...tauler-notify-v0.1.1) - 2026-08-12

### Fixed

- *(deps)* update rust crate zbus to 5.19.0 ([#357](https://github.com/kantord/tauler/pull/357))
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.1.1](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.0...tauler-screenshot-v0.1.1) - 2026-08-12

### Other

- updated the following local packages: tauler
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).