### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/kantord/tauler/compare/tauler-v0.1.1...tauler-v0.1.2) - 2026-08-13
+
+### Added
+
+- improve i3 layout ergonomics ([#364](https://github.com/kantord/tauler/pull/364))
+- simplify gaps policy ([#361](https://github.com/kantord/tauler/pull/361))
+
+### Fixed
+
+- *(deps)* update rust crate takumi to 2.7.2 ([#362](https://github.com/kantord/tauler/pull/362))
+- *(deps)* update takumi crates ([#360](https://github.com/kantord/tauler/pull/360))
+
+### Other
+
+- migrate spec.md to individual adr files
+- document i3 layout system ([#365](https://github.com/kantord/tauler/pull/365))
+- *(deps)* lock file maintenance ([#353](https://github.com/kantord/tauler/pull/353))
+
 ## [0.1.1](https://github.com/kantord/tauler/compare/tauler-v0.1.0...tauler-v0.1.1) - 2026-08-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "cached",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "image",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -4671,7 +4671,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -4681,7 +4681,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "image",
@@ -4691,7 +4691,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-ui-macro"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-i3", "tauler-notify", "tauler-ui-macro", "tauler-docgen"
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"
@@ -74,7 +74,7 @@ thiserror = "2.0.20"
 json-canon = "0.1.3"
 anyhow = "1.0.104"
 serde_yaml = "0.9.34"
-tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.0" }
+tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.2" }
 optative = "0.1.4"
 optative-process-pool = "0.0.9"
 optative-derive = "0.0.4"

--- a/tauler-i3/CHANGELOG.md
+++ b/tauler-i3/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/kantord/tauler/compare/tauler-i3-v0.1.1...tauler-i3-v0.1.2) - 2026-08-13
+
+### Added
+
+- simplify gaps policy ([#361](https://github.com/kantord/tauler/pull/361))

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.1...tauler-screenshot-v0.1.2) - 2026-08-13
+
+### Other
+
+- updated the following local packages: tauler
+
 ## [0.1.1](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.0...tauler-screenshot-v0.1.1) - 2026-08-12
 
 ### Other

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -26,7 +26,7 @@ name = "tauler-screenshot"
 path = "src/main.rs"
 
 [dependencies]
-tauler = { path = "..", version = "0.1.1" }
+tauler = { path = "..", version = "0.1.2" }
 clap = { version = "4.6.6", features = ["derive"] }
 image = "0.25.10"
 serde_json = "1.0.151"

--- a/tauler-ui-macro/CHANGELOG.md
+++ b/tauler-ui-macro/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.1...tauler-ui-macro-v0.1.2) - 2026-08-13
+
+### Added
+
+- improve i3 layout ergonomics ([#364](https://github.com/kantord/tauler/pull/364))


### PR DESCRIPTION



## 🤖 New release

* `tauler-ui-macro`: 0.1.1 -> 0.1.2
* `tauler`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `tauler-i3`: 0.1.1 -> 0.1.2
* `tauler-screenshot`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler-ui-macro`

<blockquote>

## [0.1.2](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.1...tauler-ui-macro-v0.1.2) - 2026-08-13

### Added

- improve i3 layout ergonomics ([#364](https://github.com/kantord/tauler/pull/364))
</blockquote>

## `tauler`

<blockquote>

## [0.1.2](https://github.com/kantord/tauler/compare/tauler-v0.1.1...tauler-v0.1.2) - 2026-08-13

### Added

- improve i3 layout ergonomics ([#364](https://github.com/kantord/tauler/pull/364))
- simplify gaps policy ([#361](https://github.com/kantord/tauler/pull/361))

### Fixed

- *(deps)* update rust crate takumi to 2.7.2 ([#362](https://github.com/kantord/tauler/pull/362))
- *(deps)* update takumi crates ([#360](https://github.com/kantord/tauler/pull/360))

### Other

- migrate spec.md to individual adr files
- document i3 layout system ([#365](https://github.com/kantord/tauler/pull/365))
- *(deps)* lock file maintenance ([#353](https://github.com/kantord/tauler/pull/353))
</blockquote>

## `tauler-i3`

<blockquote>

## [0.1.2](https://github.com/kantord/tauler/compare/tauler-i3-v0.1.1...tauler-i3-v0.1.2) - 2026-08-13

### Added

- simplify gaps policy ([#361](https://github.com/kantord/tauler/pull/361))
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.1.2](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.1...tauler-screenshot-v0.1.2) - 2026-08-13

### Other

- updated the following local packages: tauler
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).