### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/kantord/tauler/compare/tauler-v0.1.2...tauler-v0.1.3) - 2026-08-14
+
+### Added
+
+- add accumulator tool ([#379](https://github.com/kantord/tauler/pull/379))
+
+### Other
+
+- add a showcase scenario + small fixes ([#378](https://github.com/kantord/tauler/pull/378))
+- add component kinds ([#374](https://github.com/kantord/tauler/pull/374))
+- retire spec.md into ADRs, the docs site and module docs ([#373](https://github.com/kantord/tauler/pull/373))
+- run tauler against real desktop in container ([#368](https://github.com/kantord/tauler/pull/368))
+
 ## [0.1.2](https://github.com/kantord/tauler/compare/tauler-v0.1.1...tauler-v0.1.2) - 2026-08-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "cached",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-accumulate"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "serde_json",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "image",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-e2e"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "image",
@@ -5697,7 +5697,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -5707,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "image",
@@ -5727,7 +5727,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-ui-macro"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-i3", "tauler-notify", "tauler-ui-macro", "tauler-docgen"
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.2...tauler-screenshot-v0.1.3) - 2026-08-14
+
+### Other
+
+- updated the following local packages: tauler
+
 ## [0.1.2](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.1...tauler-screenshot-v0.1.2) - 2026-08-13
 
 ### Other

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -26,7 +26,7 @@ name = "tauler-screenshot"
 path = "src/main.rs"
 
 [dependencies]
-tauler = { path = "..", version = "0.1.2" }
+tauler = { path = "..", version = "0.1.3" }
 clap = { version = "4.6.6", features = ["derive"] }
 image = "0.25.10"
 serde_json = "1.0.151"


### PR DESCRIPTION



## 🤖 New release

* `tauler`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `tauler-screenshot`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler`

<blockquote>

## [0.1.3](https://github.com/kantord/tauler/compare/tauler-v0.1.2...tauler-v0.1.3) - 2026-08-14

### Added

- add accumulator tool ([#379](https://github.com/kantord/tauler/pull/379))

### Other

- add a showcase scenario + small fixes ([#378](https://github.com/kantord/tauler/pull/378))
- add component kinds ([#374](https://github.com/kantord/tauler/pull/374))
- retire spec.md into ADRs, the docs site and module docs ([#373](https://github.com/kantord/tauler/pull/373))
- run tauler against real desktop in container ([#368](https://github.com/kantord/tauler/pull/368))
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.1.3](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.2...tauler-screenshot-v0.1.3) - 2026-08-14

### Other

- updated the following local packages: tauler
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).