### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/kantord/tauler/compare/tauler-v0.1.4...tauler-v0.1.5) - 2026-08-15
+
+### Added
+
+- add rotary knob component ([#399](https://github.com/kantord/tauler/pull/399))
+- add slider component ([#396](https://github.com/kantord/tauler/pull/396))
+
+### Other
+
+- add more fixtures ([#386](https://github.com/kantord/tauler/pull/386))
+
 ## [0.1.3](https://github.com/kantord/tauler/compare/tauler-v0.1.2...tauler-v0.1.3) - 2026-08-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "cached",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-accumulate"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "serde_json",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "image",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-e2e"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "image",
@@ -5697,7 +5697,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -5707,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "image",
@@ -5727,7 +5727,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-ui-macro"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-i3", "tauler-notify", "tauler-ui-macro", "tauler-docgen"
 resolver = "2"
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"
@@ -78,7 +78,7 @@ serde_yaml = "0.9.34"
 # requirement admits one, so a stale floor silently verifies `tauler` against
 # the *published* macro. That is invisible until the two disagree — which is
 # exactly what happened when the macro stopped hard-coding its tag list.
-tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.4" }
+tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.5" }
 optative = "0.1.4"
 optative-process-pool = "0.0.9"
 optative-derive = "0.0.4"

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.4...tauler-screenshot-v0.1.5) - 2026-08-15
+
+### Added
+
+- add slider component ([#396](https://github.com/kantord/tauler/pull/396))
+
 ## [0.1.3](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.2...tauler-screenshot-v0.1.3) - 2026-08-14
 
 ### Other

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/main.rs"
 # manifest. A floor low enough to admit a published release makes `cargo publish
 # --dry-run` verify this crate against *that* release instead of the local one, so any
 # rename here compiles locally and fails in CI.
-tauler = { path = "..", version = "0.1.4" }
+tauler = { path = "..", version = "0.1.5" }
 clap = { version = "4.6.6", features = ["derive"] }
 image = "0.25.10"
 serde_json = "1.0.151"

--- a/tauler-ui-macro/CHANGELOG.md
+++ b/tauler-ui-macro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.4...tauler-ui-macro-v0.1.5) - 2026-08-15
+
+### Added
+
+- add slider component ([#396](https://github.com/kantord/tauler/pull/396))
+
 ## [0.1.2](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.1...tauler-ui-macro-v0.1.2) - 2026-08-13
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `tauler-ui-macro`: 0.1.4 -> 0.1.5
* `tauler`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `tauler-screenshot`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler-ui-macro`

<blockquote>

## [0.1.5](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.4...tauler-ui-macro-v0.1.5) - 2026-08-15

### Added

- add slider component ([#396](https://github.com/kantord/tauler/pull/396))
</blockquote>

## `tauler`

<blockquote>

## [0.1.5](https://github.com/kantord/tauler/compare/tauler-v0.1.4...tauler-v0.1.5) - 2026-08-15

### Added

- add rotary knob component ([#399](https://github.com/kantord/tauler/pull/399))
- add slider component ([#396](https://github.com/kantord/tauler/pull/396))

### Other

- add more fixtures ([#386](https://github.com/kantord/tauler/pull/386))
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.1.5](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.4...tauler-screenshot-v0.1.5) - 2026-08-15

### Added

- add slider component ([#396](https://github.com/kantord/tauler/pull/396))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).