### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/kantord/tauler/compare/tauler-v0.1.5...tauler-v0.1.6) - 2026-08-17
+
+### Fixed
+
+- tear down modules before re-exec ([#411](https://github.com/kantord/tauler/pull/411))
+- *(deps)* pin dependencies ([#407](https://github.com/kantord/tauler/pull/407))
+- *(deps)* update takumi crates ([#405](https://github.com/kantord/tauler/pull/405))
+
+### Other
+
+- sync intra-workspace version requirements in the release PR ([#413](https://github.com/kantord/tauler/pull/413))
+- *(deps)* lock file maintenance ([#412](https://github.com/kantord/tauler/pull/412))
+- *(deps)* update rust crate criterion to 0.8.2 ([#410](https://github.com/kantord/tauler/pull/410))
+- improve render timing ([#406](https://github.com/kantord/tauler/pull/406))
+- improve repaint scheduling ([#400](https://github.com/kantord/tauler/pull/400))
+
 ## [0.1.5](https://github.com/kantord/tauler/compare/tauler-v0.1.4...tauler-v0.1.5) - 2026-08-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5737,7 +5737,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "cached",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-accumulate"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "serde_json",
@@ -5781,7 +5781,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "image",
@@ -5791,7 +5791,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-e2e"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "image",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -5811,7 +5811,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "image",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-ui-macro"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ serde_yaml = "0.9.34"
 # requirement admits one, so a stale floor silently verifies `tauler` against
 # the *published* macro. That is invisible until the two disagree — which is
 # exactly what happened when the macro stopped hard-coding its tag list.
-tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.5" }
+tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.6" }
 optative = "=0.1.4"
 optative-process-pool = "=0.0.9"
 optative-derive = "=0.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-i3", "tauler-notify", "tauler-ui-macro", "tauler-docgen"
 resolver = "2"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.5...tauler-screenshot-v0.1.6) - 2026-08-17
+
+### Other
+
+- updated the following local packages: tauler
+
 ## [0.1.5](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.4...tauler-screenshot-v0.1.5) - 2026-08-15
 
 ### Added

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/main.rs"
 # manifest. A floor low enough to admit a published release makes `cargo publish
 # --dry-run` verify this crate against *that* release instead of the local one, so any
 # rename here compiles locally and fails in CI.
-tauler = { path = "..", version = "0.1.5" }
+tauler = { path = "..", version = "0.1.6" }
 clap = { version = "4.6.6", features = ["derive"] }
 image = "0.25.10"
 serde_json = "1.0.151"


### PR DESCRIPTION



## 🤖 New release

* `tauler`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `tauler-screenshot`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler`

<blockquote>

## [0.1.6](https://github.com/kantord/tauler/compare/tauler-v0.1.5...tauler-v0.1.6) - 2026-08-17

### Fixed

- tear down modules before re-exec ([#411](https://github.com/kantord/tauler/pull/411))
- *(deps)* pin dependencies ([#407](https://github.com/kantord/tauler/pull/407))
- *(deps)* update takumi crates ([#405](https://github.com/kantord/tauler/pull/405))

### Other

- sync intra-workspace version requirements in the release PR ([#413](https://github.com/kantord/tauler/pull/413))
- *(deps)* lock file maintenance ([#412](https://github.com/kantord/tauler/pull/412))
- *(deps)* update rust crate criterion to 0.8.2 ([#410](https://github.com/kantord/tauler/pull/410))
- improve render timing ([#406](https://github.com/kantord/tauler/pull/406))
- improve repaint scheduling ([#400](https://github.com/kantord/tauler/pull/400))
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.1.6](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.5...tauler-screenshot-v0.1.6) - 2026-08-17

### Other

- updated the following local packages: tauler
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).