### PR TITLE
chore: release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/kantord/tauler/compare/tauler-v0.1.7...tauler-v0.1.8) - 2026-08-19
+
+### Fixed
+
+- *(deps)* update rust crate takumi to v2.10.0 ([#401](https://github.com/kantord/tauler/pull/401))
+
+### Other
+
+- *(deps)* lock file maintenance ([#436](https://github.com/kantord/tauler/pull/436))
+- add a basic landing page ([#427](https://github.com/kantord/tauler/pull/427))
+
 ## [0.1.7](https://github.com/kantord/tauler/compare/tauler-v0.1.6...tauler-v0.1.7) - 2026-08-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "cached",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-accumulate"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap",
  "serde_json",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-aerospace"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "serde_json",
  "tracing",
@@ -5997,7 +5997,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "optative-script",
  "rquickjs",
@@ -6014,7 +6014,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap",
  "image",
@@ -6026,7 +6026,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-e2e"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "image",
@@ -6036,7 +6036,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -6046,7 +6046,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -6056,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap",
  "image",
@@ -6066,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-ui-macro"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6076,7 +6076,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "tauler-core",
  "wasm-bindgen",
@@ -6084,7 +6084,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web-e2e"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "headless_chrome",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-core", "tauler-web", "tauler-i3", "tauler-aerospace", "t
 resolver = "2"
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,10 +78,10 @@ serde_yaml = "0.9.34"
 # requirement admits one, so a stale floor silently verifies `tauler` against
 # the *published* macro. That is invisible until the two disagree — which is
 # exactly what happened when the macro stopped hard-coding its tag list.
-tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.7" }
+tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.8" }
 # The wasm-clean subset, with the QuickJS half switched on. Same version pinning
 # rationale as `tauler-ui-macro` above.
-tauler-core = { path = "tauler-core", version = "0.1.7", features = ["quickjs"] }
+tauler-core = { path = "tauler-core", version = "0.1.8", features = ["quickjs"] }
 optative = "=0.1.4"
 optative-process-pool = "=0.0.9"
 optative-derive = "=0.0.4"

--- a/tauler-core/Cargo.toml
+++ b/tauler-core/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 serde_yaml = "0.9.34"
 thiserror = "2.0.20"
-tauler-ui-macro = { path = "../tauler-ui-macro", version = "0.1.7" }
+tauler-ui-macro = { path = "../tauler-ui-macro", version = "0.1.8" }
 
 # The QuickJS half: registration, the `EsEntry` table and `UiComponent::js_fn`. Enabled by
 # `tauler`, never by the web build — `rquickjs-sys` compiles QuickJS from C and there is no

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.7...tauler-screenshot-v0.1.8) - 2026-08-19
+
+### Other
+
+- updated the following local packages: tauler
+
 ## [0.1.7](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.6...tauler-screenshot-v0.1.7) - 2026-08-18
 
 ### Added

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/main.rs"
 # manifest. A floor low enough to admit a published release makes `cargo publish
 # --dry-run` verify this crate against *that* release instead of the local one, so any
 # rename here compiles locally and fails in CI.
-tauler = { path = "..", version = "0.1.7" }
+tauler = { path = "..", version = "0.1.8" }
 clap = { version = "4.6.6", features = ["derive"] }
 image = "0.25.10"
 serde_json = "1.0.151"


### PR DESCRIPTION



## 🤖 New release

* `tauler`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
* `tauler-screenshot`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler`

<blockquote>

## [0.1.8](https://github.com/kantord/tauler/compare/tauler-v0.1.7...tauler-v0.1.8) - 2026-08-19

### Fixed

- *(deps)* update rust crate takumi to v2.10.0 ([#401](https://github.com/kantord/tauler/pull/401))

### Other

- *(deps)* lock file maintenance ([#436](https://github.com/kantord/tauler/pull/436))
- add a basic landing page ([#427](https://github.com/kantord/tauler/pull/427))
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.1.8](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.7...tauler-screenshot-v0.1.8) - 2026-08-19

### Other

- updated the following local packages: tauler
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).