### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/kantord/tauler/compare/tauler-v0.1.8...tauler-v0.1.9) - 2026-08-22
+
+### Added
+
+- make it easy to make anything reconcilable ([#447](https://github.com/kantord/tauler/pull/447))
+
+### Fixed
+
+- refuse to start on an unusable theme.file ([#449](https://github.com/kantord/tauler/pull/449))
+
 ## [0.1.8](https://github.com/kantord/tauler/compare/tauler-v0.1.7...tauler-v0.1.8) - 2026-08-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "cached",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-accumulate"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "clap",
  "serde_json",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-aerospace"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "serde_json",
  "tracing",
@@ -5997,7 +5997,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "optative-script",
  "rquickjs",
@@ -6014,7 +6014,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "clap",
  "image",
@@ -6026,7 +6026,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-e2e"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "image",
@@ -6036,7 +6036,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -6046,7 +6046,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -6056,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "clap",
  "image",
@@ -6066,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-ui-macro"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6076,7 +6076,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "tauler-core",
  "wasm-bindgen",
@@ -6084,7 +6084,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web-e2e"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "headless_chrome",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ serde_yaml = "0.9.34"
 # requirement admits one, so a stale floor silently verifies `tauler` against
 # the *published* macro. That is invisible until the two disagree — which is
 # exactly what happened when the macro stopped hard-coding its tag list.
-tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.8" }
+tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.9" }
 # The wasm-clean subset, with the QuickJS half switched on. Same version pinning
 # rationale as `tauler-ui-macro` above.
 tauler-core = { path = "tauler-core", version = "0.1.9", features = ["quickjs"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-core", "tauler-web", "tauler-i3", "tauler-aerospace", "t
 resolver = "2"
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"
@@ -81,7 +81,7 @@ serde_yaml = "0.9.34"
 tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.8" }
 # The wasm-clean subset, with the QuickJS half switched on. Same version pinning
 # rationale as `tauler-ui-macro` above.
-tauler-core = { path = "tauler-core", version = "0.1.8", features = ["quickjs"] }
+tauler-core = { path = "tauler-core", version = "0.1.9", features = ["quickjs"] }
 optative = "=0.1.4"
 optative-process-pool = "=0.0.9"
 optative-derive = "=0.0.4"

--- a/tauler-core/CHANGELOG.md
+++ b/tauler-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/kantord/tauler/compare/tauler-core-v0.1.8...tauler-core-v0.1.9) - 2026-08-22
+
+### Added
+
+- make it easy to make anything reconcilable ([#447](https://github.com/kantord/tauler/pull/447))
+
 ## [0.1.7](https://github.com/kantord/tauler/compare/tauler-core-v0.1.6...tauler-core-v0.1.7) - 2026-08-18
 
 ### Added

--- a/tauler-core/Cargo.toml
+++ b/tauler-core/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 serde_yaml = "0.9.34"
 thiserror = "2.0.20"
-tauler-ui-macro = { path = "../tauler-ui-macro", version = "0.1.8" }
+tauler-ui-macro = { path = "../tauler-ui-macro", version = "0.1.9" }
 
 # The QuickJS half: registration, the `EsEntry` table and `UiComponent::js_fn`. Enabled by
 # `tauler`, never by the web build — `rquickjs-sys` compiles QuickJS from C and there is no

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.8...tauler-screenshot-v0.1.9) - 2026-08-22
+
+### Other
+
+- updated the following local packages: tauler
+
 ## [0.1.8](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.7...tauler-screenshot-v0.1.8) - 2026-08-19
 
 ### Other

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/main.rs"
 # manifest. A floor low enough to admit a published release makes `cargo publish
 # --dry-run` verify this crate against *that* release instead of the local one, so any
 # rename here compiles locally and fails in CI.
-tauler = { path = "..", version = "0.1.8" }
+tauler = { path = "..", version = "0.1.9" }
 clap = { version = "4.6.6", features = ["derive"] }
 image = "0.25.10"
 serde_json = "1.0.151"


### PR DESCRIPTION



## 🤖 New release

* `tauler-core`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `tauler`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `tauler-screenshot`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler-core`

<blockquote>

## [0.1.9](https://github.com/kantord/tauler/compare/tauler-core-v0.1.8...tauler-core-v0.1.9) - 2026-08-22

### Added

- make it easy to make anything reconcilable ([#447](https://github.com/kantord/tauler/pull/447))
</blockquote>

## `tauler`

<blockquote>

## [0.1.9](https://github.com/kantord/tauler/compare/tauler-v0.1.8...tauler-v0.1.9) - 2026-08-22

### Added

- make it easy to make anything reconcilable ([#447](https://github.com/kantord/tauler/pull/447))

### Fixed

- refuse to start on an unusable theme.file ([#449](https://github.com/kantord/tauler/pull/449))
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.1.9](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.8...tauler-screenshot-v0.1.9) - 2026-08-22

### Other

- updated the following local packages: tauler
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).