### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/kantord/tauler/compare/tauler-v0.1.10...tauler-v0.2.0) - 2026-08-23
+
+### Added
+
+- use "real" optative on landing page demo ([#468](https://github.com/kantord/tauler/pull/468))
+- support .op.mdx files ([#467](https://github.com/kantord/tauler/pull/467))
+- support custom font rules ([#463](https://github.com/kantord/tauler/pull/463))
+
+### Fixed
+
+- stop release-plz sweeping tauler-ui-macro's version ([#465](https://github.com/kantord/tauler/pull/465))
+
 ## [0.1.10](https://github.com/kantord/tauler/compare/tauler-v0.1.9...tauler-v0.1.10) - 2026-08-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5943,7 +5943,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cached",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-accumulate"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "clap",
  "serde_json",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-aerospace"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "serde_json",
  "tracing",
@@ -5997,7 +5997,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-core"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "optative",
  "optative-script",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "clap",
  "image",
@@ -6027,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-e2e"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "image",
@@ -6037,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -6047,7 +6047,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "clap",
  "image",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-ui-macro"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6077,7 +6077,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "tauler-core",
  "wasm-bindgen",
@@ -6085,7 +6085,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web-e2e"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "headless_chrome",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-core", "tauler-web", "tauler-i3", "tauler-aerospace", "t
 resolver = "2"
 
 [workspace.package]
-version = "0.1.10"
+version = "0.2.0"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"
@@ -78,10 +78,10 @@ serde_yaml = "0.9.34"
 # requirement admits one, so a stale floor silently verifies `tauler` against
 # the *published* macro. That is invisible until the two disagree — which is
 # exactly what happened when the macro stopped hard-coding its tag list.
-tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.10" }
+tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.11" }
 # The wasm-clean subset, with the QuickJS half switched on. Same version pinning
 # rationale as `tauler-ui-macro` above.
-tauler-core = { path = "tauler-core", version = "0.1.10", features = ["quickjs"] }
+tauler-core = { path = "tauler-core", version = "0.2.0", features = ["quickjs"] }
 optative = "=0.1.4"
 optative-process-pool = "=0.0.9"
 optative-derive = "=0.0.4"

--- a/tauler-core/CHANGELOG.md
+++ b/tauler-core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/kantord/tauler/compare/tauler-core-v0.1.10...tauler-core-v0.2.0) - 2026-08-23
+
+### Added
+
+- use "real" optative on landing page demo ([#468](https://github.com/kantord/tauler/pull/468))
+- support custom font rules ([#463](https://github.com/kantord/tauler/pull/463))
+
 ## [0.1.9](https://github.com/kantord/tauler/compare/tauler-core-v0.1.8...tauler-core-v0.1.9) - 2026-08-22
 
 ### Added

--- a/tauler-core/Cargo.toml
+++ b/tauler-core/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 serde_yaml = "0.9.34"
 thiserror = "2.0.20"
-tauler-ui-macro = { path = "../tauler-ui-macro", version = "0.1.10" }
+tauler-ui-macro = { path = "../tauler-ui-macro", version = "0.1.11" }
 # The Unit reconciler's diff core (units_reconcile.rs): pure, no QuickJS, so it
 # belongs here rather than behind the `quickjs` feature — a browser Unit needs
 # the same diffing native Units get (ADR 0037).

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.10...tauler-screenshot-v0.1.11) - 2026-08-23
+
+### Other
+
+- updated the following local packages: tauler
+
 ## [0.1.10](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.9...tauler-screenshot-v0.1.10) - 2026-08-22
 
 ### Added

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/main.rs"
 # manifest. A floor low enough to admit a published release makes `cargo publish
 # --dry-run` verify this crate against *that* release instead of the local one, so any
 # rename here compiles locally and fails in CI.
-tauler = { path = "..", version = "0.1.10" }
+tauler = { path = "..", version = "0.2.0" }
 clap = { version = "4.6.6", features = ["derive"] }
 image = "0.25.10"
 serde_json = "1.0.151"

--- a/tauler-ui-macro/CHANGELOG.md
+++ b/tauler-ui-macro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.10...tauler-ui-macro-v0.1.11) - 2026-08-23
+
+### Fixed
+
+- stop release-plz sweeping tauler-ui-macro's version ([#465](https://github.com/kantord/tauler/pull/465))
+
 ## [0.1.7](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.6...tauler-ui-macro-v0.1.7) - 2026-08-18
 
 ### Added

--- a/tauler-ui-macro/Cargo.toml
+++ b/tauler-ui-macro/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 # only when release-plz decides *this* crate needs releasing, which is the
 # one code path release-plz gets right: rewriting every dependent's
 # `version = "..."` requirement to match.
-version = "0.1.10"
+version = "0.1.11"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `tauler-ui-macro`: 0.1.10 -> 0.1.11
* `tauler-core`: 0.1.10 -> 0.2.0 (⚠ API breaking changes)
* `tauler`: 0.1.10 -> 0.2.0 (✓ API compatible changes)
* `tauler-screenshot`: 0.1.10 -> 0.1.11

### ⚠ `tauler-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Theme.fonts in /tmp/.tmpbBoRrp/tauler/tauler-core/src/theme/mod.rs:31
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler-ui-macro`

<blockquote>

## [0.1.11](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.10...tauler-ui-macro-v0.1.11) - 2026-08-23

### Fixed

- stop release-plz sweeping tauler-ui-macro's version ([#465](https://github.com/kantord/tauler/pull/465))
</blockquote>

## `tauler-core`

<blockquote>

## [0.2.0](https://github.com/kantord/tauler/compare/tauler-core-v0.1.10...tauler-core-v0.2.0) - 2026-08-23

### Added

- use "real" optative on landing page demo ([#468](https://github.com/kantord/tauler/pull/468))
- support custom font rules ([#463](https://github.com/kantord/tauler/pull/463))
</blockquote>

## `tauler`

<blockquote>

## [0.2.0](https://github.com/kantord/tauler/compare/tauler-v0.1.10...tauler-v0.2.0) - 2026-08-23

### Added

- use "real" optative on landing page demo ([#468](https://github.com/kantord/tauler/pull/468))
- support .op.mdx files ([#467](https://github.com/kantord/tauler/pull/467))
- support custom font rules ([#463](https://github.com/kantord/tauler/pull/463))

### Fixed

- stop release-plz sweeping tauler-ui-macro's version ([#465](https://github.com/kantord/tauler/pull/465))
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.1.11](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.10...tauler-screenshot-v0.1.11) - 2026-08-23

### Other

- updated the following local packages: tauler
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).