### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/kantord/tauler/compare/tauler-v0.2.0...tauler-v0.2.1) - 2026-08-26
+
+### Fixed
+
+- *(deps)* update rust crate takumi to v2.11.0 ([#477](https://github.com/kantord/tauler/pull/477))
+- *(deps)* update rust crate optative-script to v0.0.11 ([#476](https://github.com/kantord/tauler/pull/476))
+
+### Other
+
+- *(deps)* lock file maintenance ([#474](https://github.com/kantord/tauler/pull/474))
+- *(deps)* update dependency rust to v1.98.0 ([#472](https://github.com/kantord/tauler/pull/472))
+
 ## [0.2.0](https://github.com/kantord/tauler/compare/tauler-v0.1.10...tauler-v0.2.0) - 2026-08-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5931,7 +5931,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "cached",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-accumulate"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "serde_json",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-aerospace"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde_json",
  "tracing",
@@ -5985,7 +5985,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "optative",
  "optative-script",
@@ -6003,7 +6003,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "image",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-e2e"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "image",
@@ -6025,7 +6025,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -6035,7 +6035,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "image",
@@ -6065,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "tauler-core",
  "wasm-bindgen",
@@ -6073,7 +6073,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web-e2e"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "headless_chrome",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-core", "tauler-web", "tauler-i3", "tauler-aerospace", "t
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"
@@ -81,7 +81,7 @@ serde_yaml = "0.9.34"
 tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.11" }
 # The wasm-clean subset, with the QuickJS half switched on. Same version pinning
 # rationale as `tauler-ui-macro` above.
-tauler-core = { path = "tauler-core", version = "0.2.0", features = ["quickjs"] }
+tauler-core = { path = "tauler-core", version = "0.2.1", features = ["quickjs"] }
 optative = "=0.1.4"
 optative-process-pool = "=0.0.9"
 optative-derive = "=0.0.4"

--- a/tauler-core/CHANGELOG.md
+++ b/tauler-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/kantord/tauler/compare/tauler-core-v0.2.0...tauler-core-v0.2.1) - 2026-08-26
+
+### Fixed
+
+- *(deps)* update rust crate optative-script to v0.0.11 ([#476](https://github.com/kantord/tauler/pull/476))
+
 ## [0.2.0](https://github.com/kantord/tauler/compare/tauler-core-v0.1.10...tauler-core-v0.2.0) - 2026-08-23
 
 ### Added

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.2.0...tauler-screenshot-v0.2.1) - 2026-08-26
+
+### Other
+
+- updated the following local packages: tauler
+
 ## [0.1.11](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.1.10...tauler-screenshot-v0.1.11) - 2026-08-23
 
 ### Other

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/main.rs"
 # manifest. A floor low enough to admit a published release makes `cargo publish
 # --dry-run` verify this crate against *that* release instead of the local one, so any
 # rename here compiles locally and fails in CI.
-tauler = { path = "..", version = "0.2.0" }
+tauler = { path = "..", version = "0.2.1" }
 clap = { version = "4.6.6", features = ["derive"] }
 image = "0.25.10"
 serde_json = "1.0.151"


### PR DESCRIPTION



## 🤖 New release

* `tauler-core`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `tauler`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `tauler-screenshot`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler-core`

<blockquote>

## [0.2.1](https://github.com/kantord/tauler/compare/tauler-core-v0.2.0...tauler-core-v0.2.1) - 2026-08-26

### Fixed

- *(deps)* update rust crate optative-script to v0.0.11 ([#476](https://github.com/kantord/tauler/pull/476))
</blockquote>

## `tauler`

<blockquote>

## [0.2.1](https://github.com/kantord/tauler/compare/tauler-v0.2.0...tauler-v0.2.1) - 2026-08-26

### Fixed

- *(deps)* update rust crate takumi to v2.11.0 ([#477](https://github.com/kantord/tauler/pull/477))
- *(deps)* update rust crate optative-script to v0.0.11 ([#476](https://github.com/kantord/tauler/pull/476))

### Other

- *(deps)* lock file maintenance ([#474](https://github.com/kantord/tauler/pull/474))
- *(deps)* update dependency rust to v1.98.0 ([#472](https://github.com/kantord/tauler/pull/472))
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.2.1](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.2.0...tauler-screenshot-v0.2.1) - 2026-08-26

### Other

- updated the following local packages: tauler
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).