### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/kantord/tauler/compare/tauler-v0.2.1...tauler-v0.2.2) - 2026-08-28
+
+### Fixed
+
+- *(deps)* update rust crate takumi to v2.12.0 ([#480](https://github.com/kantord/tauler/pull/480))
+
 ## [0.2.1](https://github.com/kantord/tauler/compare/tauler-v0.2.0...tauler-v0.2.1) - 2026-08-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5931,7 +5931,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "cached",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-accumulate"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "serde_json",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-aerospace"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde_json",
  "tracing",
@@ -5985,7 +5985,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "optative",
  "optative-script",
@@ -6003,7 +6003,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "image",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-e2e"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "image",
@@ -6025,7 +6025,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -6035,7 +6035,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "image",
@@ -6055,7 +6055,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-ui-macro"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6065,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "tauler-core",
  "wasm-bindgen",
@@ -6073,7 +6073,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web-e2e"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "headless_chrome",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-core", "tauler-web", "tauler-i3", "tauler-aerospace", "t
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"
@@ -78,10 +78,10 @@ serde_yaml = "0.9.34"
 # requirement admits one, so a stale floor silently verifies `tauler` against
 # the *published* macro. That is invisible until the two disagree — which is
 # exactly what happened when the macro stopped hard-coding its tag list.
-tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.11" }
+tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.12" }
 # The wasm-clean subset, with the QuickJS half switched on. Same version pinning
 # rationale as `tauler-ui-macro` above.
-tauler-core = { path = "tauler-core", version = "0.2.1", features = ["quickjs"] }
+tauler-core = { path = "tauler-core", version = "0.2.2", features = ["quickjs"] }
 optative = "=0.1.4"
 optative-process-pool = "=0.0.9"
 optative-derive = "=0.0.4"

--- a/tauler-core/CHANGELOG.md
+++ b/tauler-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/kantord/tauler/compare/tauler-core-v0.2.1...tauler-core-v0.2.2) - 2026-08-28
+
+### Other
+
+- updated the following local packages: tauler-ui-macro
+
 ## [0.2.1](https://github.com/kantord/tauler/compare/tauler-core-v0.2.0...tauler-core-v0.2.1) - 2026-08-26
 
 ### Fixed

--- a/tauler-core/Cargo.toml
+++ b/tauler-core/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 serde_yaml = "0.9.34"
 thiserror = "2.0.20"
-tauler-ui-macro = { path = "../tauler-ui-macro", version = "0.1.11" }
+tauler-ui-macro = { path = "../tauler-ui-macro", version = "0.1.12" }
 # The Unit reconciler's diff core (units_reconcile.rs): pure, no QuickJS, so it
 # belongs here rather than behind the `quickjs` feature — a browser Unit needs
 # the same diffing native Units get (ADR 0037).

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.2.1...tauler-screenshot-v0.2.2) - 2026-08-28
+
+### Other
+
+- updated the following local packages: tauler
+
 ## [0.2.1](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.2.0...tauler-screenshot-v0.2.1) - 2026-08-26
 
 ### Other

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/main.rs"
 # manifest. A floor low enough to admit a published release makes `cargo publish
 # --dry-run` verify this crate against *that* release instead of the local one, so any
 # rename here compiles locally and fails in CI.
-tauler = { path = "..", version = "0.2.1" }
+tauler = { path = "..", version = "0.2.2" }
 clap = { version = "4.6.6", features = ["derive"] }
 image = "0.25.10"
 serde_json = "1.0.151"

--- a/tauler-ui-macro/CHANGELOG.md
+++ b/tauler-ui-macro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.11...tauler-ui-macro-v0.1.12) - 2026-08-28
+
+### Fixed
+
+- *(deps)* update rust crate syn to 3.0.4 ([#481](https://github.com/kantord/tauler/pull/481))
+
 ## [0.1.11](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.10...tauler-ui-macro-v0.1.11) - 2026-08-23
 
 ### Fixed

--- a/tauler-ui-macro/Cargo.toml
+++ b/tauler-ui-macro/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 # only when release-plz decides *this* crate needs releasing, which is the
 # one code path release-plz gets right: rewriting every dependent's
 # `version = "..."` requirement to match.
-version = "0.1.11"
+version = "0.1.12"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `tauler-ui-macro`: 0.1.11 -> 0.1.12
* `tauler`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `tauler-core`: 0.2.1 -> 0.2.2
* `tauler-screenshot`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler-ui-macro`

<blockquote>

## [0.1.12](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.11...tauler-ui-macro-v0.1.12) - 2026-08-28

### Fixed

- *(deps)* update rust crate syn to 3.0.4 ([#481](https://github.com/kantord/tauler/pull/481))
</blockquote>

## `tauler`

<blockquote>

## [0.2.2](https://github.com/kantord/tauler/compare/tauler-v0.2.1...tauler-v0.2.2) - 2026-08-28

### Fixed

- *(deps)* update rust crate takumi to v2.12.0 ([#480](https://github.com/kantord/tauler/pull/480))
</blockquote>

## `tauler-core`

<blockquote>

## [0.2.2](https://github.com/kantord/tauler/compare/tauler-core-v0.2.1...tauler-core-v0.2.2) - 2026-08-28

### Other

- updated the following local packages: tauler-ui-macro
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.2.2](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.2.1...tauler-screenshot-v0.2.2) - 2026-08-28

### Other

- updated the following local packages: tauler
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).