### PR TITLE
chore: release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/kantord/tauler/compare/tauler-v0.2.4...tauler-v0.2.5) - 2026-08-30
+
+### Other
+
+- updated the following local packages: tauler-core
+
 ## [0.2.4](https://github.com/kantord/tauler/compare/tauler-v0.2.3...tauler-v0.2.4) - 2026-08-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "cached",
@@ -6036,7 +6036,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-accumulate"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "clap",
  "serde_json",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-aerospace"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "serde_json",
  "tracing",
@@ -6053,7 +6053,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "optative",
  "optative-script",
@@ -6071,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "clap",
  "insta",
@@ -6082,7 +6082,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-e2e"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "image",
@@ -6092,7 +6092,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -6102,7 +6102,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "clap",
  "serde_json",
@@ -6131,7 +6131,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "tauler-core",
  "wasm-bindgen",
@@ -6139,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web-e2e"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "headless_chrome",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-core", "tauler-web", "tauler-i3", "tauler-aerospace", "t
 resolver = "2"
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"
@@ -83,7 +83,7 @@ serde_yaml = "0.9.34"
 tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.12" }
 # The wasm-clean subset, with the QuickJS half switched on. Same version pinning
 # rationale as `tauler-ui-macro` above.
-tauler-core = { path = "tauler-core", version = "0.2.4", features = ["quickjs"] }
+tauler-core = { path = "tauler-core", version = "0.2.5", features = ["quickjs"] }
 optative = "=0.1.4"
 optative-process-pool = "=0.0.9"
 optative-derive = "=0.0.4"

--- a/tauler-core/CHANGELOG.md
+++ b/tauler-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/kantord/tauler/compare/tauler-core-v0.2.4...tauler-core-v0.2.5) - 2026-08-30
+
+### Added
+
+- add scroll area component ([#499](https://github.com/kantord/tauler/pull/499))
+
 ## [0.2.2](https://github.com/kantord/tauler/compare/tauler-core-v0.2.1...tauler-core-v0.2.2) - 2026-08-28
 
 ### Other

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.2.4...tauler-screenshot-v0.2.5) - 2026-08-30
+
+### Other
+
+- updated the following local packages: tauler
+
 ## [0.2.4](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.2.3...tauler-screenshot-v0.2.4) - 2026-08-30
 
 ### Other

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -30,6 +30,6 @@ path = "src/main.rs"
 # manifest. A floor low enough to admit a published release makes `cargo publish
 # --dry-run` verify this crate against *that* release instead of the local one, so any
 # rename here compiles locally and fails in CI.
-tauler = { path = "..", version = "0.2.4" }
+tauler = { path = "..", version = "0.2.5" }
 clap = { version = "4.6.6", features = ["derive"] }
 serde_json = "1.0.151"


### PR DESCRIPTION



## 🤖 New release

* `tauler-core`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `tauler`: 0.2.4 -> 0.2.5
* `tauler-screenshot`: 0.2.4 -> 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler-core`

<blockquote>

## [0.2.5](https://github.com/kantord/tauler/compare/tauler-core-v0.2.4...tauler-core-v0.2.5) - 2026-08-30

### Added

- add scroll area component ([#499](https://github.com/kantord/tauler/pull/499))
</blockquote>

## `tauler`

<blockquote>

## [0.2.5](https://github.com/kantord/tauler/compare/tauler-v0.2.4...tauler-v0.2.5) - 2026-08-30

### Other

- updated the following local packages: tauler-core
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.2.5](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.2.4...tauler-screenshot-v0.2.5) - 2026-08-30

### Other

- updated the following local packages: tauler
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).