### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/kantord/tauler/compare/tauler-v0.3.0...tauler-v0.3.1) - 2026-09-06
+
+### Added
+
+- add <Workspaces /> wrapper ([#523](https://github.com/kantord/tauler/pull/523))
+- add basic accesskit integration ([#505](https://github.com/kantord/tauler/pull/505))
+
+### Fixed
+
+- *(deps)* update takumi crates ([#520](https://github.com/kantord/tauler/pull/520))
+
 ## [0.3.0](https://github.com/kantord/tauler/compare/tauler-v0.2.5...tauler-v0.3.0) - 2026-09-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-accumulate"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "serde_json",
@@ -6116,7 +6116,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-aerospace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde_json",
  "tracing",
@@ -6125,7 +6125,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "optative",
  "optative-script",
@@ -6143,7 +6143,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "insta",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-e2e"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "image",
@@ -6164,7 +6164,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -6174,7 +6174,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "serde_json",
@@ -6203,7 +6203,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tauler-core",
  "wasm-bindgen",
@@ -6211,7 +6211,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web-e2e"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "headless_chrome",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-core", "tauler-web", "tauler-i3", "tauler-aerospace", "t
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"
@@ -83,7 +83,7 @@ serde_yaml = "0.9.34"
 tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.12" }
 # The wasm-clean subset, with the QuickJS half switched on. Same version pinning
 # rationale as `tauler-ui-macro` above.
-tauler-core = { path = "tauler-core", version = "0.3.0", features = ["quickjs"] }
+tauler-core = { path = "tauler-core", version = "0.3.1", features = ["quickjs"] }
 optative = "=0.1.4"
 optative-process-pool = "=0.0.9"
 optative-derive = "=0.0.4"

--- a/tauler-accumulate/CHANGELOG.md
+++ b/tauler-accumulate/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/tauler-aerospace/CHANGELOG.md
+++ b/tauler-aerospace/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/tauler-core/CHANGELOG.md
+++ b/tauler-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/kantord/tauler/compare/tauler-core-v0.3.0...tauler-core-v0.3.1) - 2026-09-06
+
+### Added
+
+- add <Workspaces /> wrapper ([#523](https://github.com/kantord/tauler/pull/523))
+
 ## [0.3.0](https://github.com/kantord/tauler/compare/tauler-core-v0.2.5...tauler-core-v0.3.0) - 2026-09-03
 
 ### Fixed

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.3.0...tauler-screenshot-v0.3.1) - 2026-09-06
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.2.6](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.2.5...tauler-screenshot-v0.2.6) - 2026-09-03
 
 ### Other

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -30,6 +30,6 @@ path = "src/main.rs"
 # manifest. A floor low enough to admit a published release makes `cargo publish
 # --dry-run` verify this crate against *that* release instead of the local one, so any
 # rename here compiles locally and fails in CI.
-tauler = { path = "..", version = "0.3.0" }
+tauler = { path = "..", version = "0.3.1" }
 clap = { version = "4.6.6", features = ["derive"] }
 serde_json = "1.0.151"


### PR DESCRIPTION



## 🤖 New release

* `tauler-core`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `tauler`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `tauler-i3`: 0.3.0 -> 0.3.1
* `tauler-aerospace`: 0.3.0 -> 0.3.1
* `tauler-notify`: 0.3.0 -> 0.3.1
* `tauler-screenshot`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `tauler-accumulate`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler-core`

<blockquote>

## [0.3.1](https://github.com/kantord/tauler/compare/tauler-core-v0.3.0...tauler-core-v0.3.1) - 2026-09-06

### Added

- add <Workspaces /> wrapper ([#523](https://github.com/kantord/tauler/pull/523))
</blockquote>

## `tauler`

<blockquote>

## [0.3.1](https://github.com/kantord/tauler/compare/tauler-v0.3.0...tauler-v0.3.1) - 2026-09-06

### Added

- add <Workspaces /> wrapper ([#523](https://github.com/kantord/tauler/pull/523))
- add basic accesskit integration ([#505](https://github.com/kantord/tauler/pull/505))

### Fixed

- *(deps)* update takumi crates ([#520](https://github.com/kantord/tauler/pull/520))
</blockquote>

## `tauler-i3`

<blockquote>

## [0.1.2](https://github.com/kantord/tauler/compare/tauler-i3-v0.1.1...tauler-i3-v0.1.2) - 2026-08-13

### Added

- simplify gaps policy ([#361](https://github.com/kantord/tauler/pull/361))
</blockquote>


## `tauler-notify`

<blockquote>

## [0.1.1](https://github.com/kantord/tauler/compare/tauler-notify-v0.1.0...tauler-notify-v0.1.1) - 2026-08-12

### Fixed

- *(deps)* update rust crate zbus to 5.19.0 ([#357](https://github.com/kantord/tauler/pull/357))
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.3.1](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.3.0...tauler-screenshot-v0.3.1) - 2026-09-06

### Other

- update Cargo.lock dependencies
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).