### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/kantord/tauler/compare/tauler-v0.3.1...tauler-v0.3.2) - 2026-09-08
+
+### Added
+
+- paint background for workspaces area ([#535](https://github.com/kantord/tauler/pull/535))
+
+### Fixed
+
+- *(deps)* update rust crate cached to v4 ([#533](https://github.com/kantord/tauler/pull/533))
+- *(deps)* update patch updates ([#532](https://github.com/kantord/tauler/pull/532))
+- *(deps)* update rust crate takumi to v2.13.6 ([#507](https://github.com/kantord/tauler/pull/507))
+- correct output DPR, primary-output, and gap-overflow bugs ([#529](https://github.com/kantord/tauler/pull/529))
+
 ## [0.3.1](https://github.com/kantord/tauler/compare/tauler-v0.3.0...tauler-v0.3.1) - 2026-09-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-accumulate"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "serde_json",
@@ -6116,7 +6116,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-aerospace"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "serde_json",
  "tracing",
@@ -6125,7 +6125,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "optative",
  "optative-script",
@@ -6143,7 +6143,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "insta",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-e2e"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "image",
@@ -6164,7 +6164,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -6174,7 +6174,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "serde_json",
@@ -6193,7 +6193,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-ui-macro"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6203,7 +6203,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "tauler-core",
  "wasm-bindgen",
@@ -6211,7 +6211,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web-e2e"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "headless_chrome",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-core", "tauler-web", "tauler-i3", "tauler-aerospace", "t
 resolver = "2"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"
@@ -80,10 +80,10 @@ serde_yaml = "0.9.34"
 # requirement admits one, so a stale floor silently verifies `tauler` against
 # the *published* macro. That is invisible until the two disagree — which is
 # exactly what happened when the macro stopped hard-coding its tag list.
-tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.12" }
+tauler-ui-macro = { path = "tauler-ui-macro", version = "0.1.13" }
 # The wasm-clean subset, with the QuickJS half switched on. Same version pinning
 # rationale as `tauler-ui-macro` above.
-tauler-core = { path = "tauler-core", version = "0.3.1", features = ["quickjs"] }
+tauler-core = { path = "tauler-core", version = "0.3.2", features = ["quickjs"] }
 optative = "=0.1.4"
 optative-process-pool = "=0.0.9"
 optative-derive = "=0.0.4"

--- a/tauler-accumulate/CHANGELOG.md
+++ b/tauler-accumulate/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.2](https://github.com/kantord/tauler/compare/tauler-accumulate-v0.3.1...tauler-accumulate-v0.3.2) - 2026-09-08
+
+### Other
+
+- update Cargo.lock dependencies

--- a/tauler-aerospace/CHANGELOG.md
+++ b/tauler-aerospace/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.2](https://github.com/kantord/tauler/compare/tauler-aerospace-v0.3.1...tauler-aerospace-v0.3.2) - 2026-09-08
+
+### Other
+
+- update Cargo.lock dependencies

--- a/tauler-core/CHANGELOG.md
+++ b/tauler-core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/kantord/tauler/compare/tauler-core-v0.3.1...tauler-core-v0.3.2) - 2026-09-08
+
+### Fixed
+
+- *(deps)* update patch updates ([#532](https://github.com/kantord/tauler/pull/532))
+- correct output DPR, primary-output, and gap-overflow bugs ([#529](https://github.com/kantord/tauler/pull/529))
+
 ## [0.3.1](https://github.com/kantord/tauler/compare/tauler-core-v0.3.0...tauler-core-v0.3.1) - 2026-09-06
 
 ### Added

--- a/tauler-core/Cargo.toml
+++ b/tauler-core/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 serde_yaml = "0.9.34"
 thiserror = "2.0.20"
-tauler-ui-macro = { path = "../tauler-ui-macro", version = "0.1.12" }
+tauler-ui-macro = { path = "../tauler-ui-macro", version = "0.1.13" }
 # The Unit reconciler's diff core (units_reconcile.rs): pure, no QuickJS, so it
 # belongs here rather than behind the `quickjs` feature — a browser Unit needs
 # the same diffing native Units get (ADR 0037).

--- a/tauler-i3/CHANGELOG.md
+++ b/tauler-i3/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/kantord/tauler/compare/tauler-i3-v0.3.1...tauler-i3-v0.3.2) - 2026-09-08
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.2](https://github.com/kantord/tauler/compare/tauler-i3-v0.1.1...tauler-i3-v0.1.2) - 2026-08-13
 
 ### Added

--- a/tauler-notify/CHANGELOG.md
+++ b/tauler-notify/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/kantord/tauler/compare/tauler-notify-v0.3.1...tauler-notify-v0.3.2) - 2026-09-08
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.1](https://github.com/kantord/tauler/compare/tauler-notify-v0.1.0...tauler-notify-v0.1.1) - 2026-08-12
 
 ### Fixed

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.3.1...tauler-screenshot-v0.3.2) - 2026-09-08
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.3.1](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.3.0...tauler-screenshot-v0.3.1) - 2026-09-06
 
 ### Other

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -30,6 +30,6 @@ path = "src/main.rs"
 # manifest. A floor low enough to admit a published release makes `cargo publish
 # --dry-run` verify this crate against *that* release instead of the local one, so any
 # rename here compiles locally and fails in CI.
-tauler = { path = "..", version = "0.3.1" }
+tauler = { path = "..", version = "0.3.2" }
 clap = { version = "4.6.6", features = ["derive"] }
 serde_json = "1.0.151"

--- a/tauler-ui-macro/CHANGELOG.md
+++ b/tauler-ui-macro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.12...tauler-ui-macro-v0.1.13) - 2026-09-08
+
+### Fixed
+
+- *(deps)* update patch updates ([#532](https://github.com/kantord/tauler/pull/532))
+
 ## [0.1.12](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.11...tauler-ui-macro-v0.1.12) - 2026-08-28
 
 ### Fixed

--- a/tauler-ui-macro/Cargo.toml
+++ b/tauler-ui-macro/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 # only when release-plz decides *this* crate needs releasing, which is the
 # one code path release-plz gets right: rewriting every dependent's
 # `version = "..."` requirement to match.
-version = "0.1.12"
+version = "0.1.13"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `tauler-ui-macro`: 0.1.12 -> 0.1.13
* `tauler-core`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `tauler`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `tauler-i3`: 0.3.1 -> 0.3.2
* `tauler-aerospace`: 0.3.1 -> 0.3.2
* `tauler-notify`: 0.3.1 -> 0.3.2
* `tauler-screenshot`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `tauler-accumulate`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler-ui-macro`

<blockquote>

## [0.1.13](https://github.com/kantord/tauler/compare/tauler-ui-macro-v0.1.12...tauler-ui-macro-v0.1.13) - 2026-09-08

### Fixed

- *(deps)* update patch updates ([#532](https://github.com/kantord/tauler/pull/532))
</blockquote>

## `tauler-core`

<blockquote>

## [0.3.2](https://github.com/kantord/tauler/compare/tauler-core-v0.3.1...tauler-core-v0.3.2) - 2026-09-08

### Fixed

- *(deps)* update patch updates ([#532](https://github.com/kantord/tauler/pull/532))
- correct output DPR, primary-output, and gap-overflow bugs ([#529](https://github.com/kantord/tauler/pull/529))
</blockquote>

## `tauler`

<blockquote>

## [0.3.2](https://github.com/kantord/tauler/compare/tauler-v0.3.1...tauler-v0.3.2) - 2026-09-08

### Added

- paint background for workspaces area ([#535](https://github.com/kantord/tauler/pull/535))

### Fixed

- *(deps)* update rust crate cached to v4 ([#533](https://github.com/kantord/tauler/pull/533))
- *(deps)* update patch updates ([#532](https://github.com/kantord/tauler/pull/532))
- *(deps)* update rust crate takumi to v2.13.6 ([#507](https://github.com/kantord/tauler/pull/507))
- correct output DPR, primary-output, and gap-overflow bugs ([#529](https://github.com/kantord/tauler/pull/529))
</blockquote>

## `tauler-i3`

<blockquote>

## [0.3.2](https://github.com/kantord/tauler/compare/tauler-i3-v0.3.1...tauler-i3-v0.3.2) - 2026-09-08

### Other

- update Cargo.lock dependencies
</blockquote>

## `tauler-aerospace`

<blockquote>

## [0.3.2](https://github.com/kantord/tauler/compare/tauler-aerospace-v0.3.1...tauler-aerospace-v0.3.2) - 2026-09-08

### Other

- update Cargo.lock dependencies
</blockquote>

## `tauler-notify`

<blockquote>

## [0.3.2](https://github.com/kantord/tauler/compare/tauler-notify-v0.3.1...tauler-notify-v0.3.2) - 2026-09-08

### Other

- update Cargo.lock dependencies
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.3.2](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.3.1...tauler-screenshot-v0.3.2) - 2026-09-08

### Other

- update Cargo.lock dependencies
</blockquote>

## `tauler-accumulate`

<blockquote>

## [0.3.2](https://github.com/kantord/tauler/compare/tauler-accumulate-v0.3.1...tauler-accumulate-v0.3.2) - 2026-09-08

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).