### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/kantord/tauler/compare/tauler-v0.3.2...tauler-v0.4.0) - 2026-09-09
+
+### Fixed
+
+- support per-display dpr ([#541](https://github.com/kantord/tauler/pull/541))
+- resync panel position when RandR output geometry changes ([#540](https://github.com/kantord/tauler/pull/540))
+- *(deps)* update rust crate takumi to v2.13.7 ([#539](https://github.com/kantord/tauler/pull/539))
+
+### Other
+
+- batch of small fixes ([#544](https://github.com/kantord/tauler/pull/544))
+- *(deps)* lock file maintenance ([#502](https://github.com/kantord/tauler/pull/502))
+- *(deps)* update rust crate rstest to 0.27.0 ([#542](https://github.com/kantord/tauler/pull/542))
+
 ## [0.3.2](https://github.com/kantord/tauler/compare/tauler-v0.3.1...tauler-v0.3.2) - 2026-09-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6056,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "tauler"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-accumulate"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "clap",
  "serde_json",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-aerospace"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "serde_json",
  "tracing",
@@ -6130,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-docgen"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "clap",
  "insta",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-e2e"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "image",
@@ -6151,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-i3"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "serde_json",
  "swayipc",
@@ -6161,7 +6161,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-notify"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6171,7 +6171,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-screenshot"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "clap",
  "serde_json",
@@ -6190,7 +6190,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "tauler-core",
  "wasm-bindgen",
@@ -6198,7 +6198,7 @@ dependencies = [
 
 [[package]]
 name = "tauler-web-e2e"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "headless_chrome",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tauler-core", "tauler-web", "tauler-i3", "tauler-aerospace", "t
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Dániel Kántor <github@daniel-kantor.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kantord/tauler"

--- a/tauler-aerospace/CHANGELOG.md
+++ b/tauler-aerospace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/kantord/tauler/compare/tauler-aerospace-v0.3.2...tauler-aerospace-v0.4.0) - 2026-09-09
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.3.2](https://github.com/kantord/tauler/compare/tauler-aerospace-v0.3.1...tauler-aerospace-v0.3.2) - 2026-09-08
 
 ### Other

--- a/tauler-i3/CHANGELOG.md
+++ b/tauler-i3/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/kantord/tauler/compare/tauler-i3-v0.3.2...tauler-i3-v0.4.0) - 2026-09-09
+
+### Fixed
+
+- support per-display dpr ([#541](https://github.com/kantord/tauler/pull/541))
+
 ## [0.3.2](https://github.com/kantord/tauler/compare/tauler-i3-v0.3.1...tauler-i3-v0.3.2) - 2026-09-08
 
 ### Other

--- a/tauler-notify/CHANGELOG.md
+++ b/tauler-notify/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/kantord/tauler/compare/tauler-notify-v0.3.2...tauler-notify-v0.4.0) - 2026-09-09
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.3.2](https://github.com/kantord/tauler/compare/tauler-notify-v0.3.1...tauler-notify-v0.3.2) - 2026-09-08
 
 ### Other

--- a/tauler-screenshot/CHANGELOG.md
+++ b/tauler-screenshot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.3.2...tauler-screenshot-v0.4.0) - 2026-09-09
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.3.2](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.3.1...tauler-screenshot-v0.3.2) - 2026-09-08
 
 ### Other

--- a/tauler-screenshot/Cargo.toml
+++ b/tauler-screenshot/Cargo.toml
@@ -30,6 +30,6 @@ path = "src/main.rs"
 # manifest. A floor low enough to admit a published release makes `cargo publish
 # --dry-run` verify this crate against *that* release instead of the local one, so any
 # rename here compiles locally and fails in CI.
-tauler = { path = "..", version = "0.3.2" }
+tauler = { path = "..", version = "0.4.0" }
 clap = { version = "4.6.6", features = ["derive"] }
 serde_json = "1.0.151"


### PR DESCRIPTION



## 🤖 New release

* `tauler`: 0.3.2 -> 0.4.0 (⚠ API breaking changes)
* `tauler-i3`: 0.3.2 -> 0.4.0
* `tauler-aerospace`: 0.3.2 -> 0.4.0
* `tauler-notify`: 0.3.2 -> 0.4.0
* `tauler-screenshot`: 0.3.2 -> 0.4.0 (✓ API compatible changes)
* `tauler-accumulate`: 0.3.2 -> 0.4.0

### ⚠ `tauler` breaking changes

```text
--- failure constructible_struct_adds_field: struct exhaustively constructible through public API adds field ---

Description:
A pub struct that could be exhaustively constructed with a literal using only public API has a new pub field, breaking existing exhaustive literals.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Panel.dpr in /tmp/.tmpokpAEC/tauler/src/x11/panel.rs:103

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/function_missing.ron

Failed in:
  function tauler::x11::panel::resolve_panel_dpr, previously in file /tmp/.tmp1po6Oi/tauler/src/x11/panel.rs:105

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/method_parameter_count_changed.ron

Failed in:
  tauler::surface::SurfaceSets::reconcile_all takes 2 parameters in /tmp/.tmp1po6Oi/tauler/src/surface/mod.rs:275, but now takes 3 parameters in /tmp/.tmpokpAEC/tauler/src/surface/mod.rs:307
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `tauler`

<blockquote>

## [0.4.0](https://github.com/kantord/tauler/compare/tauler-v0.3.2...tauler-v0.4.0) - 2026-09-09

### Fixed

- support per-display dpr ([#541](https://github.com/kantord/tauler/pull/541))
- resync panel position when RandR output geometry changes ([#540](https://github.com/kantord/tauler/pull/540))
- *(deps)* update rust crate takumi to v2.13.7 ([#539](https://github.com/kantord/tauler/pull/539))

### Other

- batch of small fixes ([#544](https://github.com/kantord/tauler/pull/544))
- *(deps)* lock file maintenance ([#502](https://github.com/kantord/tauler/pull/502))
- *(deps)* update rust crate rstest to 0.27.0 ([#542](https://github.com/kantord/tauler/pull/542))
</blockquote>

## `tauler-i3`

<blockquote>

## [0.4.0](https://github.com/kantord/tauler/compare/tauler-i3-v0.3.2...tauler-i3-v0.4.0) - 2026-09-09

### Fixed

- support per-display dpr ([#541](https://github.com/kantord/tauler/pull/541))
</blockquote>

## `tauler-aerospace`

<blockquote>

## [0.4.0](https://github.com/kantord/tauler/compare/tauler-aerospace-v0.3.2...tauler-aerospace-v0.4.0) - 2026-09-09

### Other

- update Cargo.lock dependencies
</blockquote>

## `tauler-notify`

<blockquote>

## [0.4.0](https://github.com/kantord/tauler/compare/tauler-notify-v0.3.2...tauler-notify-v0.4.0) - 2026-09-09

### Other

- update Cargo.lock dependencies
</blockquote>

## `tauler-screenshot`

<blockquote>

## [0.4.0](https://github.com/kantord/tauler/compare/tauler-screenshot-v0.3.2...tauler-screenshot-v0.4.0) - 2026-09-09

### Other

- update Cargo.lock dependencies
</blockquote>

## `tauler-accumulate`

<blockquote>

## [0.3.2](https://github.com/kantord/tauler/compare/tauler-accumulate-v0.3.1...tauler-accumulate-v0.3.2) - 2026-09-08

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).